### PR TITLE
Sorting in Ratings, Watchlist and User List pages have been changed.

### DIFF
--- a/js/filmlistHeader.js
+++ b/js/filmlistHeader.js
@@ -355,16 +355,14 @@ function getDirectionParam() {
     return direction;
 }
 
-function onChangeSort() {
-    // Set sort direction to default
-    setSortDirection();
-    
+function onChangeSort(direction, isRatingsPage) {
+    setSortDirection(direction, isRatingsPage);    
     setFilmlistFilter();
 }
 
-function setSortDirection(direction) {
+function setSortDirection(direction, isRatingsPage) {
     var directionEl = document.getElementById("direction");
-    var imageEl = document.getElementById("direction-image");
+    var iconEls = document.getElementsByName("direction-image");
 
     // Use default (desc) unless it is specifcally setting to asc
     if (!direction || direction != "asc") {
@@ -375,18 +373,22 @@ function setSortDirection(direction) {
         directionEl.value = direction;
     }
 
-    if (imageEl) {
-        if (direction == "asc") {
-            imageEl.setAttribute("src", "/image/sort-asc.png");
-            imageEl.setAttribute("alt", "Ascending order");
-        } else {
-            imageEl.setAttribute("src", "/image/sort-desc.png");
-            imageEl.setAttribute("alt", "Descending order");
+    // Show the one icon appropriate and hide the rest
+    for (var i = 0; i < iconEls.length; i++) {
+        var el = iconEls[i];
+        el.hidden = true;
+
+        var iconDirection = el.getAttribute("data-direction");
+        var iconForPage = el.getAttribute("data-page");
+        var isIconForRatingsPage = iconForPage == "ratings";
+
+        if (direction == iconDirection && !isRatingsPage == !isIconForRatingsPage) {
+            el.removeAttribute("hidden");
         }
-    }
+    } 
 }
 
-function toggleSortDirection() {
+function toggleSortDirection(isRatingsPage) {
     var direction = "desc";
     var directionEl = document.getElementById("direction");
 
@@ -394,7 +396,7 @@ function toggleSortDirection() {
         direction = "asc";
     }
 
-    setSortDirection(direction);
+    setSortDirection(direction, isRatingsPage);
     setFilmlistFilter();
 }
 

--- a/php/ratings.php
+++ b/php/ratings.php
@@ -17,6 +17,10 @@ $pageNum = array_value_by_key("p", $_POST);
 if (empty($pageNum)) {
     $pageNum = 1;
 }
+$sort = array_value_by_key("sort", $_POST);
+if (empty($sort)) {
+    $sort = "date";
+}
 $sortDirection = array_value_by_key("direction", $_POST);
 if (empty($sortDirection)) {
     $sortDirection = "desc";
@@ -24,7 +28,7 @@ if (empty($sortDirection)) {
 
 if (!empty($username)) {
     $listnames = Filmlist::getUserListsFromDbByParent($username, false);
-    $filmlistHeader = getHtmlUserlistHeader($listnames, $sortDirection, null, Constants::RATINGS_PAGE_LABEL);
+    $filmlistHeader = getHtmlUserlistHeader($listnames, $sort, $sortDirection, null, Constants::RATINGS_PAGE_LABEL);
     $filmlistPagination = getHmtlFilmlistPagination("./ratings.php");
 }
 

--- a/php/src/RatingSyncSite.php
+++ b/php/src/RatingSyncSite.php
@@ -15,7 +15,8 @@ require_once "SiteRatings.php";
 class RatingSyncSite extends \RatingSync\SiteRatings
 {
     const RATINGSYNC_DATE_FORMAT = "n/j/y";
-    const SORT_MODIFIED     = 'yourRatingDate';
+    const SORT_RATING_DATE  = 'yourRatingDate';
+    const SORT_YOUR_SCORE   = 'yourScore';
     const SORTDIR_ASC       = 'ASC';
     const SORTDIR_DESC      = 'DESC';
 
@@ -58,7 +59,7 @@ class RatingSyncSite extends \RatingSync\SiteRatings
         $this->http = new Http($this->sourceName, $username);
         $this->dateFormat = self::RATINGSYNC_DATE_FORMAT;
         $this->maxCriticScore = 100;
-        $this->sort = static::SORT_MODIFIED;
+        $this->sort = static::SORT_RATING_DATE;
         $this->sortDirection = static::SORTDIR_DESC;
         $this->clearContentTypeFilter();
         $this->clearListFilter();
@@ -66,7 +67,7 @@ class RatingSyncSite extends \RatingSync\SiteRatings
 
     public static function validSort($sort)
     {
-        $validSorts = array(static::SORT_MODIFIED);
+        $validSorts = array(static::SORT_RATING_DATE, static::SORT_YOUR_SCORE);
         if (in_array($sort, $validSorts)) {
             return true;
         }
@@ -164,7 +165,10 @@ class RatingSyncSite extends \RatingSync\SiteRatings
         $refreshCache = Constants::USE_CACHE_NEVER;
         $films = array();
 
-        $orderBy = "ORDER BY yourRatingDate " . $this->getSortDirection();
+        $orderBy = "";
+        if (!empty($this->getSort())) {
+            $orderBy = "ORDER BY " . $this->getSort() . " " . $this->getSortDirection();
+        }
 
         $limit = "";
         if (!empty($limitPages)) {

--- a/php/src/ajax/api.php
+++ b/php/src/ajax/api.php
@@ -388,7 +388,7 @@ function api_getRatings($username)
     $filtergenres = array_value_by_key("filtergenres", $_GET);
     $filtergenreany = array_value_by_key("filtergenreany", $_GET);
     $filtercontenttypes = array_value_by_key("filtercontenttypes", $_GET);
-    logDebug("Params ps=$pageSize, bp=$beginPage, sort=$sort (ignored), sortDirection=$sortDirection, filterlists=$filterlists, filtergenres=$filtergenres, filtergenreany=$filtergenreany, filtercontenttypes=$filtercontenttypes", __FUNCTION__." ".__LINE__);
+    logDebug("Params ps=$pageSize, bp=$beginPage, sort=$sort, sortDirection=$sortDirection, filterlists=$filterlists, filtergenres=$filtergenres, filtergenreany=$filtergenreany, filtercontenttypes=$filtercontenttypes", __FUNCTION__." ".__LINE__);
     
     if (empty($pageSize)) {
         $pageSize = null;
@@ -397,20 +397,20 @@ function api_getRatings($username)
         $beginPage = 1;
     }
 
-    if (strtolower($sort) == "pos") {
-        $sort = Filmlist::SORT_POSITION;
-    } elseif (strtolower($sort) == "mod") {
-        $sort = Filmlist::SORT_ADDED;
-    } elseif (!Filmlist::validSortDirection($sort)) {
-        $sort = Filmlist::SORT_ADDED;
+    if (strtolower($sort) == "date") {
+        $sort = RatingSyncSite::SORT_RATING_DATE;
+    } elseif (strtolower($sort) == "score") {
+        $sort = RatingSyncSite::SORT_YOUR_SCORE;
+    } elseif (!RatingSyncSite::validSort($sort)) {
+        $sort = RatingSyncSite::SORT_RATING_DATE;
     }
 
     if (strtolower($sortDirection) == "desc") {
-        $sortDirection = Filmlist::SORTDIR_DESC;
+        $sortDirection = RatingSyncSite::SORTDIR_DESC;
     } elseif (strtolower($sortDirection) == "asc") {
-        $sortDirection = Filmlist::SORTDIR_ASC;
-    } elseif (!Filmlist::validSortDirection($sortDirection)) {
-        $sortDirection = Filmlist::SORTDIR_DESC;
+        $sortDirection = RatingSyncSite::SORTDIR_ASC;
+    } elseif (!RatingSyncSite::validSortDirection($sortDirection)) {
+        $sortDirection = RatingSyncSite::SORTDIR_DESC;
     }
 
     // Filter by other lists. Return only films in this list that
@@ -450,6 +450,7 @@ function api_getRatings($username)
     }
 
     $site = new \RatingSync\RatingSyncSite($username);
+    $site->setSort($sort);
     $site->setSortDirection($sortDirection);
     $site->setListFilter($filterListsArr);
     $site->setGenreFilter($filterGenresArr);
@@ -497,7 +498,7 @@ function api_getFilmsByList($username)
         $sort = Filmlist::SORT_POSITION;
     } elseif (strtolower($sort) == "mod") {
         $sort = Filmlist::SORT_ADDED;
-    } elseif (!Filmlist::validSortDirection($sort)) {
+    } elseif (!Filmlist::validSort($sort)) {
         $sort = Filmlist::SORT_POSITION;
     }
 

--- a/php/src/ajax/getHtmlFilmlists.php
+++ b/php/src/ajax/getHtmlFilmlists.php
@@ -5,7 +5,7 @@ require_once __DIR__ . DIRECTORY_SEPARATOR . ".." . DIRECTORY_SEPARATOR . ".." .
 require_once __DIR__ . DIRECTORY_SEPARATOR . ".." . DIRECTORY_SEPARATOR . "Constants.php";
 require_once __DIR__ . DIRECTORY_SEPARATOR . ".." . DIRECTORY_SEPARATOR . "Genre.php";
 
-function getHtmlUserlistHeader($listnames, $sortDirection, $currentListname = "", $displayListname = "", $offerFilter = true) {
+function getHtmlUserlistHeader($listnames, $sort, $sortDirection, $currentListname = "", $displayListname = "", $offerFilter = true) {
     $username = getUsername();
     if ($displayListname == "") {
         $displayListname = $currentListname;
@@ -66,19 +66,37 @@ function getHtmlUserlistHeader($listnames, $sortDirection, $currentListname = ""
     $contentFilterHtml .= '</div>'."\n";
 
     // Sort
-    $hiddenSort = "";
+    $isRatingsPage = false;
     if ($displayListname == Constants::RATINGS_PAGE_LABEL) {
-        $hiddenSort = "hidden";
+        $isRatingsPage = true;
     }
-    $sortImage = "/image/sort-$sortDirection.png";
+    $sortOptionsHtml = "";
+    $hiddenSort = "";
+    if ($isRatingsPage) {
+        $selectedDate = $sort == "date" ? "selected" : "";
+        $selectedScore = $sort == "score" ? "selected" : "";
+        $sortOptionsHtml .= '    <option value="date" '.$selectedDate.'>Date</option>'."\n";
+        $sortOptionsHtml .= '    <option value="score" '.$selectedScore.'>Stars</option>'."\n";
+    } else {
+        $hiddenSort = "hidden";
+        $selectedPos = $sort == "pos" ? "selected" : "";
+        $selectedMod = $sort == "mod" ? "selected" : "";
+        $sortOptionsHtml .= '    <option value="pos" '.$selectedPos.'>Position</option>'."\n";
+        $sortOptionsHtml .= '    <option value="mod" '.$selectedMod.'>Added</option>'."\n";
+    }
     $sortHtml = "";
-    $sortHtml .= '<select class="ml-auto"  id="sort" onchange="onChangeSort();" '.$hiddenSort.'>'."\n";
-    $sortHtml .= '  <option value="pos">Position</option>'."\n";
-    $sortHtml .= '  <option value="mod">Added</option>'."\n";
+    $sortHtml  = '<select class="ml-auto mt-3"  id="sort" onchange="onChangeSort(\'desc\', '.$isRatingsPage.');" '.$hiddenSort.'>'."\n";
+    $sortHtml .=    $sortOptionsHtml;
     $sortHtml .= '</select>'."\n";
+    $sortHtml .= '<a href="javascript:void(0);" style="text-decoration: none; color: inherit;">'."\n";
+    $sortHtml .= '  '.getHtmlSortDirectionIcon("direction-image-asc-ratings",  true,  "asc",  $sortDirection, $isRatingsPage)."\n";
+    $sortHtml .= '  '.getHtmlSortDirectionIcon("direction-image-desc-ratings", true,  "desc", $sortDirection, $isRatingsPage)."\n";
+    $sortHtml .= '  '.getHtmlSortDirectionIcon("direction-image-asc-list",     false, "asc",  $sortDirection, $isRatingsPage)."\n";
+    $sortHtml .= '  '.getHtmlSortDirectionIcon("direction-image-desc-list",    false, "desc", $sortDirection, $isRatingsPage)."\n";
+    $sortHtml .= '</a>'."\n";
     $sortHtml .= '<input type="text" id="direction" value="' . $sortDirection . '" hidden>'."\n";
-    $sortHtml .= '<a href="javascript:void(0);"><img id="direction-image" height="25px" alt="Ascending order" src="' . $sortImage . '" onclick="toggleSortDirection();"></a>'."\n";
-    
+    $sortHtml .= '<input type="text" id="sort" value="' . $sort . '" hidden>'."\n";
+
     $html = "\n";
     $html .= '' . "\n";
     $html .= "<div class='card bg-light mt-3'>\n";
@@ -200,6 +218,58 @@ function getHtmlContentTypeForFilter() {
         $html .= '    <a href="javascript:void(0)" '.$onClick.' id="contenttype-filter-'.$contentType.'">'.$checkmark.$contentTypes[$contentType].'</a>'."\n";
     }
 
+    return $html;
+}
+
+function getHtmlSortDirectionIcon($id, $forRatingsPage, $direction, $currentDirection, $isRatingsPage) {
+    // These are attributes for the new element
+    //   class     - font awesome image
+    //   name     - onClick function will need to know which icons to hide or show
+    //   direction - asc/desc
+    //   page      - page name: ratings/list
+    //   onClick   - do the sorting and hide/show the right icons
+    //   title     - text to show when the user hovers
+    //   hidden    - "hidden" or "". Only one icon is showing at a time.
+
+    // class
+    $upOrDown = "down";
+    if ($direction == "asc") {
+        $upOrDown = "up";
+    }
+
+    $class = "class='fas fa-sort-amount-$upOrDown'";
+
+    // name
+    $name = "name='direction-image'";
+
+    // direction attribute
+    $directionAttr = "data-direction='$direction'";
+
+    // page
+    $page = "data-page='list'";
+    if ($forRatingsPage) {
+        $page = "data-page='ratings'";
+    }
+
+    // onClick
+    $iconIsForRatingsPage = $forRatingsPage ? "true" : "false";
+    $onClick = 'onClick="toggleSortDirection(\''.$iconIsForRatingsPage.'\');"';
+    
+    // title
+    $title = "Descending order";
+    if ($direction == "asc") {
+        $title = "Ascending order";
+    }
+    $title = "title='$title'";
+
+    // hidden
+    $hidden = "hidden";
+    if ($forRatingsPage == $isRatingsPage && $direction == $currentDirection) {
+        $hidden = "";
+    }
+
+    $html = "<i $class $name $directionAttr $page $onClick $title $hidden></i>"."\n";
+    
     return $html;
 }
 

--- a/php/userlist.php
+++ b/php/userlist.php
@@ -15,6 +15,10 @@ if (empty($listname)) {
     $listname = array_value_by_key("l", $_POST);
 }
 $pageNum = array_value_by_key("p", $_POST);
+$sort = array_value_by_key("sort", $_POST);
+if (empty($sort)) {
+    $sort = "position";
+}
 $sortDirection = array_value_by_key("direction", $_POST);
 if (empty($sortDirection)) {
     $sortDirection = "desc";
@@ -33,7 +37,7 @@ if (!empty($username)) {
 
     $offerListFilter = true;
 
-    $filmlistHeader = getHtmlUserlistHeader($listnames, $sortDirection, $listname, null, $offerListFilter);
+    $filmlistHeader = getHtmlUserlistHeader($listnames, $sort, $sortDirection, $listname, null, $offerListFilter);
     $filmlistPagination = getHmtlFilmlistPagination("./userlist.php?l=" . $listname);
 }
 


### PR DESCRIPTION
The ratings page has 2 options for sorting: rating date & score.
Watchlist/Userlist had 2 options, but the "Added" has been removed because it's hard to tell the difference between Position and Added. It was confusing to users. The functionality is still in the code, but the Select is hidden.
#31 