### PR TITLE
Vertical center the poster image for episodes whenever a overlay is n…

### DIFF
--- a/css/rs.css
+++ b/css/rs.css
@@ -107,6 +107,10 @@ poster > div > a {
     border-radius: .3rem;
 }
 
+poster.watchit-normal > div > a {
+    margin-top: 3.75rem;
+}
+
 poster.watchit-overlay > div > a {
     background-size: cover;
     background-position: center;


### PR DESCRIPTION
…ot used for WatchIt buttons. In other words, center the image when episode images are in wide opposed to cropped. Cropped images fill the whole space. Wide episode images leave empty space vertically.