### PR TITLE
Hot fix 2 on release v1.20250414

### DIFF
--- a/php/ExternalAdapters/ExternalAdapter.php
+++ b/php/ExternalAdapters/ExternalAdapter.php
@@ -217,7 +217,7 @@ abstract class ExternalAdapter
 
         foreach ( $inactiveRatings as $inactiveRating ) {
 
-            if ( $inactiveRating->isInitiated() ) {
+            if ( $inactiveRating?->isInitiated() ) {
                 try {
                     $entries[] = $this->buildEntry($externalFilm, $inactiveRating);
                 } catch (Exception) {
@@ -227,7 +227,7 @@ abstract class ExternalAdapter
 
         }
 
-        if ( $rating->isInitiated() ) {
+        if ( $rating?->isInitiated() ) {
             try {
                 $entries[] = $this->buildEntry($externalFilm, $rating);
             } catch (Exception) {


### PR DESCRIPTION
#88 ExternalAdapter->getExportEntriesForFilm() calls Rating->isInitiated() without checking for null.